### PR TITLE
Demonstrate width issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,6 +39,9 @@
 
 .Modal {
   position: absolute;
+  width: 480px;
+  border: 1px solid red;
+  background: white;
 }
 
 form {


### PR DESCRIPTION
The CodatLink component seems to not be consistent with whether the consumer is responsible for rendering the modal or if CodatLink is. In this sample, the consumer code has to create the container and position it in the center of the screen, however then the CodatLink component is attempting to be responsible for the width and the box shadows.

In our application we have a design system already in place for modals that renders a scrim, a box shadow, and is responsive with a max width of 480px. It will take up the full 480px if there is space. Below a certain width (i.e. mobile) we position and display our modal differently so it takes the full width.

IMO the CodatLink component needs to either be responsible for the entire "modal" aspect, or continue relying on the conumer placing it in a modal and no defining a fixed width (or if you have to define a fixed width for your content, removing the box shadow and centering the content should be suffcient)

![image](https://github.com/codatio/sample-project-link-sdk/assets/85186764/31760e04-669d-4bae-a976-c2251595aa61)
